### PR TITLE
C++ solution using a Functor

### DIFF
--- a/solutions/complete/c++/soln2/goal.cpp
+++ b/solutions/complete/c++/soln2/goal.cpp
@@ -6,7 +6,6 @@
 
 #include <string>
 #include <iostream>
-#include <sstream>
 
 struct g
 {


### PR DESCRIPTION
Some abuse of the function operator means no #define needed in this solution.
