### PR TITLE
Mathematica solution

### DIFF
--- a/solutions/complete/mathematica/soln1/goal.m
+++ b/solutions/complete/mathematica/soln1/goal.m
@@ -1,9 +1,9 @@
 f[n_] := (
 	If[Length@{##} == 1,
-		"g" <> StringJoin @@ Table["o", {n}] <> "al",
+		"g" <> StringJoin @@ Table["o", {n}] <> First@{##},
 		f[n + 1]]
 	) &;
-g["al"] := "gal";
+g[x_] := f[0][x];
 g[] := f[1];
 
 (* Test *)


### PR DESCRIPTION
Mathematica uses square brackets `[]` instead of normal parenthesis for function invocation.

Hope you don't mind.
