### PR TITLE
Add rationale for no solution in PHP

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ already been discovered:
 | Java          |                       |                 |                   | [&bull;][java-nonsoln1] |
 | JavaScript    | [&bull;][js-soln2]    |                 |                   |                         |
 | Julia         | [&bull;][jl-soln1]    |                 |                   |                         |
+| PHP           |                       |                 |                   | [&bull;][php-nonsoln1]  |
 | Python        | [&bull;][py-soln1]    |                 |                   |                         |
 | R             | [&bull;][r-soln1]     |                 |                   |                         |
 | Ruby          |                       |                 |                   | [&bull;][rb-nonsoln1]   |
@@ -64,6 +65,7 @@ Help out, add some more languages!
 [go-soln]: https://github.com/eatnumber1/goal/tree/master/solutions/complete/go/soln1
 [hs-soln1]: https://github.com/eatnumber1/goal/tree/master/solutions/complete/haskell/soln1
 [js-soln2]: https://github.com/eatnumber1/goal/tree/master/solutions/complete/javascript/soln2
+[php-nonsoln1]: https://github.com/eatnumber1/goal/tree/master/non-solutions/php/nonsoln1
 [py-soln1]: https://github.com/eatnumber1/goal/tree/master/solutions/complete/python/soln1
 [r-soln1]: https://github.com/eatnumber1/goal/tree/master/solutions/complete/r/soln1
 [rb-nonsoln1]: https://github.com/eatnumber1/goal/tree/master/non-solutions/ruby/nonsoln1

--- a/non-solutions/php/nonsoln1/README
+++ b/non-solutions/php/nonsoln1/README
@@ -1,0 +1,3 @@
+PHP does not yet support a nested function dereferencing syntax (i.e. foo()()). 
+This may change in the future should the Uniform Variable Syntax 
+(https://wiki.php.net/rfc/uniform_variable_syntax) be accepted.


### PR DESCRIPTION
PHP cannot have a solution given the rules due to its lack of support for nested function dereferencing. The following will always produce a syntax error:

``` php
<?Php

g()()('al');
g()('al');
```

This may be possible in the future should the [Uniform Variable Syntax](https://wiki.php.net/rfc/uniform_variable_syntax) RFC get accepted.
