### PR TITLE
JavaScript 1.8 version that only uses 58 characters

### DIFF
--- a/solutions/complete/javascript/panzi-2/goal.js
+++ b/solutions/complete/javascript/panzi-2/goal.js
@@ -1,8 +1,10 @@
-// only 58 characters using JavaScript 1.8 expression closures
+// only 46 characters using JavaScript 1.8 expression closures
 // only supported by Firefox 3+
 // https://developer.mozilla.org/en-US/docs/Web/JavaScript/New_in_JavaScript/1.8#Expression_closures_(Merge_into_own_page.2Fsection)
+// credits for the => syntax go to /u/inmatarian
+// http://www.reddit.com/r/programming/comments/2btrvt/gal/cj97o5f
 
-function g(a,o)a?'g'+(o||'')+a:function(a)g(a,(o||'')+'o')
+g=(a,o)=>a?'g'+(o||'')+a:(a)=>g(a,(o||'')+'o')
 
 console.log(g('al'));
 console.log(g()('al'));


### PR DESCRIPTION
This is a JavaScript 1.8 version that uses even less characters. JavaScript 1.8 is currently only supported by Firefox (and only using `<script language="JavaScript1.8">` or in the debug console/in an add-on). This is why I didn't put it in the javascript directory. Should I put it there anyway? As panzi2? Or should the javascript folder be renamed to ecmascript and javascript1.8 to javascript?
