### PR TITLE
Add two ocaml implementations

### DIFF
--- a/non-solutions/ocaml/def-lkb/cps.ml
+++ b/non-solutions/ocaml/def-lkb/cps.ml
@@ -1,0 +1,12 @@
+(* Not a proper solution because *normally* we shouldn't be able to change the
+   purpose of (), but here is a more natural encoding in FP-style *)
+let g k = k "g"
+let o s k = k (s ^ "o")
+let al s = s ^ "al"
+
+let () =
+  print_endline (g al);
+  print_endline (g o al);
+  print_endline (g o o al);
+  print_endline (g o o o al);
+  print_endline (g o o o o al)

--- a/solutions/complete/ocaml/def-lkb/parser_hack.ml
+++ b/solutions/complete/ocaml/def-lkb/parser_hack.ml
@@ -1,0 +1,21 @@
+(* The code rely on a hack of the parser allowing to define () as a value
+   constructor. The code is still completely type-safe. *)
+type _ goal =
+  | () : ('a goal -> 'a) goal
+  | Al : string goal
+
+let rec g : type a. int -> a goal -> a = fun n -> function
+  | () -> g (succ n)
+  | Al -> "g" ^ String.make n 'o' ^ "al"
+
+let g x = g 0 x
+let al = Al
+
+(* We have to annotate the type to prevent the compiler thinking of the "()"
+   pattern as the one we just redefined *)
+let () : unit =
+  print_endline (g al);
+  print_endline (g()al);
+  print_endline (g()()al);
+  print_endline (g()()()al);
+  print_endline (g()()()()al)


### PR DESCRIPTION
One non-solution following a classic continuation-passing-style encoding.
One solution extending the previous one with some tricks.

Namely:
− a parsing tricks allowing definition of "()" as a value constructor only
− mixing CPS and GADTs to give the appropriate type to ()
