### PR TITLE
scorpiona c-sharp

### DIFF
--- a/solutions/complete/c-sharp/scorpiona/MetaDataReader.cs
+++ b/solutions/complete/c-sharp/scorpiona/MetaDataReader.cs
@@ -1,0 +1,95 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace goal
+{
+    class MetaDataReader
+    {
+        readonly IMetaDataImport metaDataImport;
+
+        public MetaDataReader(string location)
+        {
+            metaDataImport = GetDataImport(location);
+        }
+
+        static IMetaDataImport GetDataImport(string location)
+        {
+            var dispenser = new IMetaDataDispenser();
+
+            var metaDataImportGuid = typeof(IMetaDataImport).GUID;
+
+            object scope;
+
+            var hr = dispenser.OpenScope(location, 0, ref metaDataImportGuid, out scope);
+            AssertHresultIsZero(hr);
+
+            return (IMetaDataImport)scope;
+        }
+
+        public IEnumerable<string> EnumerateUserStrings()
+        {
+            return EnumerateUserStringIds().Select(GetUserString);
+        }
+
+        string GetUserString(uint id)
+        {
+            var length = GetUserStringLength(id);
+
+            return GetUserStringContent(id, length);
+        }
+
+        uint GetUserStringLength(uint id)
+        {
+            uint length;
+
+            var hr = metaDataImport.GetUserString(id, null, 0, out length);
+            AssertHresultIsZero(hr);
+
+            return length;
+        }
+
+        string GetUserStringContent(uint id, uint length)
+        {
+            var buffer = new char[length];
+
+            var hr = metaDataImport.GetUserString(id, buffer, length, out length);
+            AssertHresultIsZero(hr);
+
+            return new string(buffer);
+        }
+
+        IEnumerable<uint> EnumerateUserStringIds()
+        {
+            var hEnum = IntPtr.Zero;
+            var buffer = new uint[16];
+
+            try
+            {
+                uint count;
+
+                do
+                {
+                    var hr = metaDataImport.EnumUserStrings(ref hEnum, buffer, (uint)buffer.Length, out count);
+                    AssertHresultIsZero(hr);
+
+                    for (var i = 0; i < count; i++)
+                        yield return buffer[i];
+                }
+                while (count > 0);
+            }
+            finally
+            {
+                metaDataImport.CloseEnum(hEnum);
+            }
+        }
+
+        static void AssertHresultIsZero(uint hr)
+        {
+            if (hr != 0)
+                Marshal.ThrowExceptionForHR((int)hr);
+        }
+    }
+}

--- a/solutions/complete/c-sharp/scorpiona/Native.cs
+++ b/solutions/complete/c-sharp/scorpiona/Native.cs
@@ -1,0 +1,93 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace goal
+{
+    #region Native
+    [ComImport, Guid("E5CB7A31-7512-11D2-89CE-0080C792E5D8")]
+    class CorMetaDataDispenser
+    {
+    }
+
+    [ComImport, Guid("809C652E-7396-11D2-9771-00A0C9B4D50C")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    [CoClass(typeof(CorMetaDataDispenser))]
+    interface IMetaDataDispenser
+    {
+        uint DefineScope(ref Guid rclsid, uint dwCreateFlags, ref Guid riid, [MarshalAs(UnmanagedType.Interface)]out object ppIUnk);
+        uint OpenScope([MarshalAs(UnmanagedType.LPWStr)]string szScope, uint dwOpenFlags, ref Guid riid, [MarshalAs(UnmanagedType.Interface)] out object ppIUnk);
+        uint OpenScopeOnMemory(IntPtr pData, uint cbData, uint dwOpenFlags, ref Guid riid, [MarshalAs(UnmanagedType.Interface)]out object ppIUnk);
+    }
+
+    [ComImport, Guid("7DAC8207-D3AE-4C75-9B67-92801A497D44")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    public interface IMetaDataImport
+    {
+        void CloseEnum(IntPtr hEnum);
+        uint CountEnum(IntPtr hEnum, out uint count);
+        uint ResetEnum(IntPtr hEnum, uint ulPos);
+        uint EnumTypeDefs(ref IntPtr phEnum, [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 2)]uint[] rTypeDefs, uint cMax, out uint pcTypeDefs);
+        uint EnumInterfaceImpls(ref IntPtr phEnum, uint td, [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 3)]uint[] rImpls, uint cMax, out uint pcImpls);
+        uint EnumTypeRefs(ref IntPtr phEnum, [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 2)]uint[] rTypeDefs, uint cMax, out uint pcTypeRefs);
+        uint FindTypeDefByName([MarshalAs(UnmanagedType.LPWStr)]string szTypeDef, uint tkEnclosingClass, out uint ptd);
+        uint GetScopeProps([MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 0)]char[] szName, uint cchName, out uint pchName, ref Guid pmvid);
+        uint GetModuleFromScope(out uint pmd);
+        uint GetTypeDefProps(uint td, [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 2)]char[] szTypeDef, uint cchTypeDef, out uint pchTypeDef, out uint pdwTypeDefFlags, out uint ptkExtends);
+        uint GetInterfaceImplProps(uint iiImpl, out uint pClass, out uint ptkIface);
+        uint GetTypeRefProps(uint tr, out uint ptkResolutionScope, [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 3)]char[] szName, uint cchName, out uint pchName);
+        uint ResolveTypeRef(uint tr, ref Guid riid, [MarshalAs(UnmanagedType.Interface)]out object ppIScope, out uint ptd);
+        uint EnumMembers(ref IntPtr phEnum, uint cl, [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 3)]uint[] rMembers, uint cMax, out uint pcTokens);
+        uint EnumMembersWithName(ref IntPtr phEnum, uint cl, [MarshalAs(UnmanagedType.LPWStr)]string szName, [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 4)]uint[] rMembers, uint cMax, out uint pcTokens);
+        uint EnumMethods(ref IntPtr phEnum, uint cl, [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 3)]uint[] rMethods, uint cMax, out uint pcTokens);
+        uint EnumMethodsWithName(ref IntPtr phEnum, uint cl, [MarshalAs(UnmanagedType.LPWStr)]string szName, [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 4)]uint[] rMethods, uint cMax, out uint pcTokens);
+        uint EnumFields(ref IntPtr phEnum, uint cl, [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 3)]uint[] rFields, uint cMax, out uint pcTokens);
+        uint EnumFieldsWithName(ref IntPtr phEnum, uint cl, [MarshalAs(UnmanagedType.LPWStr)]string szName, [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 4)]uint[] rFields, uint cMax, out uint pcTokens);
+        uint EnumParams(ref IntPtr phEnum, uint mb, [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 3)]uint[] rParams, uint cMax, out uint pcTokens);
+        uint EnumMemberRefs(ref IntPtr phEnum, uint tkParent, [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 3)]uint[] rMemberRefs, uint cMax, out uint pcTokens);
+        uint EnumMethodImpls(ref IntPtr phEnum, uint td, [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 2)]uint[] rMethodBody, [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 3)]uint[] rMethodDecl, uint cMax, out uint pcTokens);
+        uint EnumPermissionSets(ref IntPtr phEnum, uint tk, uint dwActions, [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 3)]uint[] rPermission, uint cMax, out uint pcTokens);
+        uint FindMember(uint td, [MarshalAs(UnmanagedType.LPWStr)]string szName, [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 2)]byte[] pvSigBlob, uint cbSigBlob, out uint pmb);
+        uint FindMethod(uint td, [MarshalAs(UnmanagedType.LPWStr)]string szName, [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 2)]byte[] pvSigBlob, uint cbSigBlob, out uint pmb);
+        uint FindField(uint td, [MarshalAs(UnmanagedType.LPWStr)]string szName, [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 2)]byte[] pvSigBlob, uint cbSigBlob, out uint pmb);
+        uint FindMemberRef(uint td, [MarshalAs(UnmanagedType.LPWStr)]string szName, [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 2)]byte[] pvSigBlob, int cbSigBlob, out uint pmr);
+        uint GetMethodProps(uint mb, out uint pClass, [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 2)]char[] szMethod, uint cchMethod, out uint pchMethod, out uint pdwAttr, out IntPtr ppvSigBlob, out uint pcbSigBlob, out uint pulCodeRVA, out uint pdwImplFlags);
+        uint GetMemberRefProps(uint mr, out uint ptk, [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 2)]char[] szMember, uint cchMember, out uint pchMember, out IntPtr ppvSigBlob, out uint pbSigBlob);
+        uint EnumProperties(ref IntPtr phEnum, uint td, [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 2)]uint[] rProperties, uint cMax, out uint pcProperties);
+        uint EnumEvents(ref IntPtr phEnum, uint td, [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 2)]uint[] rEvents, uint cMax, out uint pcEvents);
+        uint GetEventProps(uint ev, out uint pClass, [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 2)]char[] szEvent, uint cchEvent, out uint pchEvent, out uint pdwEventFlags, out uint ptkEventType, out uint pmdAddOn, out uint pmdRemoveOn, out uint pmdFire, [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 10)]uint[] rmdOtherMethod, uint cMax, out uint pcOtherMethod);
+        uint EnumMethodSemantics(ref IntPtr phEnum, uint mb, [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 2)]uint[] rEventProp, uint cMax, out uint pcEventProp);
+        uint GetMethodSemantics(uint mb, uint tkEventProp, out uint pdwSemanticsFlags);
+        uint GetClassLayout(uint td, out uint pdwPackSize, [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 2)]long[] rFieldOffset, uint cMax, out uint pcFieldOffset, out uint pulClassSize);
+        uint GetFieldMarshal(uint tk, out IntPtr ppvNativeType, out uint pcbNativeType);
+        uint GetRVA(uint tk, out uint pulCodeRVA, out uint pdwImplFlags);
+        uint GetPermissionSetProps(uint pm, out uint pdwAction, out IntPtr ppvPermission, out uint pcbPermission);
+        uint GetSigFromToken(uint mdSig, out IntPtr ppvSig, out uint pcbSig);
+        uint GetModuleRefProps(uint mur, [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 1)]char[] szName, uint cchName, out uint pchName);
+        uint EnumModuleRefs(ref IntPtr phEnum, [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 1)]uint[] rModuleRefs, uint cmax, out uint pcModuleRefs);
+        uint GetTypeSpecFromToken(uint typespec, out IntPtr ppvSig, out uint pcbSig);
+        uint GetNameFromToken(uint tk, out IntPtr pszUtf8NamePtr);
+        uint EnumUnresolvedMethods(ref uint phEnum, [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 1)]uint[] rMethods, uint cMax, out uint pcTokens);
+        uint GetUserString(uint stk, [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 1)] char[] szString, uint cchString, out uint pchString);
+        uint GetPinvokeMap(uint tk, out uint pdwMappingFlags, [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 2)]char[] szImportName, uint cchImportName, out uint pchImportName, out uint pmrImportDLL);
+        uint EnumSignatures(ref IntPtr phEnum, [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 1)]uint[] rSignatures, uint cmax, out uint pcSignatures);
+        uint EnumTypeSpecs(ref IntPtr phEnum, [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 1)]uint[] rTypeSpecs, uint cmax, out uint pcTypeSpecs);
+        uint EnumUserStrings(ref IntPtr phEnum, [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 1)]uint[] rStrings, uint cmax, out uint pcStrings);
+        uint GetParamForMethodIndex(uint md, uint ulParamSeq, out uint ppd);
+        uint EnumCustomAttributes(ref IntPtr phEnum, uint tk, uint tkType, [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 3)]uint[] rCustomAttributes, uint cMax, out uint pcCustomAttributes);
+        uint GetCustomAttributeProps(uint cv, out uint ptkObj, out uint ptkType, out IntPtr ppBlob, out uint pcbSize);
+        uint FindTypeRef(uint tkResolutionScope, [MarshalAs(UnmanagedType.LPWStr)]string szName, out uint ptr);
+        uint GetMemberProps(uint mb, out uint pClass, [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 2)]char[] szMember, uint cchMember, out uint pchMember, out uint pdwAttr, out IntPtr ppvSigBlob, out uint pcbSigBlob, out uint pulCodeRVA, out uint pdwImplFlags, out uint pdwCPlusTypeFlag, out IntPtr ppValue, out uint pcchValue);
+        uint GetFieldProps(uint mb, out uint pClass, [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 2)]char[] szField, uint cchField, out uint pchField, out uint pdwAttr, out IntPtr ppvSigBlob, out uint pcbSigBlob, out uint pdwCPlusTypeFlag, out IntPtr ppValue, out uint pcchValue);
+        uint GetPropertyProps(uint prop, out uint pClass, [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 2)]char[] szProperty, uint cchProperty, out uint pchProperty, out uint pdwPropFlags, out IntPtr ppvSig, out uint pbSig, out uint pdwCPlusTypeFlag, out IntPtr ppDefaultValue, out uint pcchDefaultValue, out uint pmdSetter, out uint pmdGetter, [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 13)]uint[] rmdOtherMethod, uint cMax, out uint pcOtherMethod);
+        uint GetParamProps(uint tk, out uint pmd, out uint pulSequence, [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 3)]char[] szName, uint cchName, out uint pchName, out uint pdwAttr, out uint pdwCPlusTypeFlag, out IntPtr ppValue, out uint pcchValue);
+        uint GetCustomAttributeByName(uint tkObj, [MarshalAs(UnmanagedType.LPWStr)]string szName, out IntPtr ppData, out uint pcbData);
+        bool IsValidToken(uint tk);
+        uint GetNestedClassProps(uint tdNestedClass, out uint ptdEnclosingClass);
+        uint GetNativeCallConvFromSig(IntPtr pvSig, uint cbSig, out uint pCallConv);
+        uint IsGlobal(uint pd, out uint pbGlobal);
+    }
+    #endregion
+}

--- a/solutions/complete/c-sharp/scorpiona/Program.cs
+++ b/solutions/complete/c-sharp/scorpiona/Program.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Runtime.InteropServices;
+using System.Reflection;
+
+namespace goal
+{
+    class Program
+    {
+        static void Main()
+        {
+            GCHandle? handle = null;
+            try
+            {
+                var str = string.Intern(EnumerateInternedStrings(Assembly.GetExecutingAssembly()).Single(a => a == "al"));
+
+                handle = GCHandle.Alloc(str, GCHandleType.Pinned);
+                var pStr = handle.Value.AddrOfPinnedObject();
+                var alsh = Marshal.ReadInt32(pStr);
+                Marshal.WriteInt32(pStr, alsh + 0x3000E);
+            }
+            finally
+            {
+                if (handle.HasValue)
+                    handle.Value.Free();
+            }
+
+            Console.WriteLine(g("al"));
+            Console.WriteLine(g()("al"));
+            Console.WriteLine(g()()("al"));
+            Console.WriteLine(g()()()("al"));
+            Console.WriteLine(g()()()()("al"));
+            Console.WriteLine(g()()()()()("al"));
+            Console.WriteLine(g()()()()()()("al"));
+            Console.WriteLine("Press any key t{0}ntinue.", "al".Insert(1, " c"));
+            Console.ReadKey();
+        }
+
+        delegate dynamic dG(params dynamic[] d);
+        static dynamic g(string a = null, int c = 0)
+        {
+            if (a == null)
+                return (dG)(d => g(d.FirstOrDefault(), c + 1));
+
+            var str = "gal";
+            for (int i = 0; i < c; i++)
+                str = str.Insert(1, a.Substring(1));
+
+            return str;
+        }
+
+        static IEnumerable<string> EnumerateInternedStrings(Assembly assembly)
+        {
+            var metaDataReader = new MetaDataReader(assembly.Location);
+            return metaDataReader.EnumerateUserStrings().Where(x => string.IsInterned(x) != null);
+        }
+    }
+}


### PR DESCRIPTION
I thought it would be inappropriate to break the tradition set in the name of the challenge by using an "o" where something else would do. So, here's a C# solution that contains no `o` in string/character representation.

I came up with the idea for using interning, and the dirty work for how to interact with it through COM was provided by [this SO answer](http://stackoverflow.com/questions/22172175/read-the-content-of-the-string-intern-pool) and @bblanchon's [implementation](https://github.com/bblanchon/CsharpLeetSpeak).
