### PR TITLE
Potentially more idiomatic solution for Go

### DIFF
--- a/solutions/complete/go/steven099/goal.go
+++ b/solutions/complete/go/steven099/goal.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+)
+
+type oSBResult *string
+
+type OStringBuilder func(strs ...interface{}) OStringBuilder
+
+func NewOStringBuilder() (builder OStringBuilder) {
+	var result bytes.Buffer
+	return func(v ...interface{}) OStringBuilder {
+		if len(v) == 0 {
+			result.WriteString("o")
+		}
+
+		for i := range v {
+			switch in := v[i].(type) {
+			case string:
+				result.WriteString(in)
+			case oSBResult:
+				*in = result.String()
+			default:
+				fmt.Fprint(&result, in)
+			}
+		}
+
+		return builder
+	}
+}
+
+func (builder OStringBuilder) String() (result string) {
+	builder(oSBResult(&result))
+	return
+}
+
+func g(v ...interface{}) OStringBuilder {
+	return NewOStringBuilder()("g")(v...)
+}
+
+func main() {
+	fmt.Println(g("al"))
+	fmt.Println(g()("al"))
+
+	for oCount := 2; oCount <= 10; oCount++ {
+		result := g
+		for i := 0; i < oCount; i++ {
+			result = result()
+		}
+		fmt.Println(result("al"))	
+	}
+}


### PR DESCRIPTION
This solution uses a closure to store the state of the result string rather than using global state. The function type of the closure, `OStringBuilder`, implements `fmt.Stringer`, which is an interface in Go which allows an arbitrary type to be printed as a string. A special argument type, `oSBResult`, is used to extract the result from the closure in the implementation of `fmt.Stringer` for `OStringBuilder`. This solution is general in that the `OStringBuilder` type can be used to build any string containing "o"s. It uses a `bytes.Buffer` to build the result, which should be more efficient for longer "goal" strings compared to appending one character to a string at a time.
