### PR TITLE
PHP solution using the zero-width space

### DIFF
--- a/non-solutions/php/ciarand/.gitignore
+++ b/non-solutions/php/ciarand/.gitignore
@@ -1,0 +1,4 @@
+/vendor
+/composer.json
+/composer.lock
+/Makefile

--- a/non-solutions/php/ciarand/README.md
+++ b/non-solutions/php/ciarand/README.md
@@ -1,0 +1,28 @@
+Just like the other entries, this is a cheap hack.
+
+>PHP does not yet support a nested function dereferencing syntax (i.e. foo()()).
+>This may change in the future should the Uniform Variable Syntax
+>(https://wiki.php.net/rfc/uniform_variable_syntax) be accepted.
+
+While this is technically true, PHP does (kind of) support unicode and unicode
+supports the zero-width space. So this works:
+
+```php
+echo g().​().​().​().​('al');
+```
+
+And so does this (gg used because you can't have two different definitions of
+g):
+
+```php
+echo gg()->​()->​()->​()->​('al');
+```
+
+If the Uniform Variable Syntax RFC passes then this solution will work as
+expected, i.e.:
+
+```php
+echo g()()("al"); // will work once (if?) the UVS passes
+```
+
+Inspired by @kopiro's original efforts

--- a/non-solutions/php/ciarand/goal.php
+++ b/non-solutions/php/ciarand/goal.php
@@ -1,0 +1,48 @@
+<?php
+
+// This is the best that you can do in PHP without going into the weird
+// self-modifying code because of this:
+// https://wiki.php.net/rfc/uniform_variable_syntax
+
+// I've inclued two ways of doing it, one using concat (.) and one using method
+// calls (->). If the UVS thing passes the __invoke method will make this 
+// solution work as expected.
+
+class Container
+{
+    private $current_string = "g";
+
+    public function ​($str = null)
+    {
+        if ($str !== null) {
+            return $this->current_string . $str;
+        }
+
+        $this->current_string .= "o";
+
+        return $this;
+    }
+
+    public function __invoke($str = null)
+    {
+        return $this->​($str);
+    }
+}
+
+function g($str = null)
+{
+    if ($str === "al") {
+        return "gal";
+    }
+
+    return new Container();
+}
+
+function gg($str = null)
+{
+    return "g" . $str;
+}
+
+function ​($str = null) {
+    return $str ?: "o";
+}

--- a/non-solutions/php/ciarand/test.phpt
+++ b/non-solutions/php/ciarand/test.phpt
@@ -1,0 +1,27 @@
+--TEST--
+g()('al') related fun
+--FILE--
+<?php require "goal.php";
+
+echo gg().​().​().​().​('al') . PHP_EOL;
+echo gg().​().​().​('al') . PHP_EOL;
+echo gg().​().​('al') . PHP_EOL;
+echo gg().​('al') . PHP_EOL;
+echo gg('al') . PHP_EOL;
+
+echo g()->​()->​()->​()->​('al') . PHP_EOL;
+echo g()->​()->​()->​('al') . PHP_EOL;
+echo g()->​()->​('al') . PHP_EOL;
+echo g()->​('al') . PHP_EOL;
+echo g('al') . PHP_EOL;
+--EXPECT--
+goooal
+gooal
+goal
+gal
+gal
+goooal
+gooal
+goal
+gal
+gal


### PR DESCRIPTION
This uses a zero-width space (U+200B) to seem smart. It basically gets
as far as code that looks like this:

```
echo gg().​().​().​().​('al');
```

Or this:

```
echo g()->​()->​()->​()->​('al');
```

As other contributors have noted, PHP's lack of a uniform variable
syntax (https://wiki.php.net/rfc/uniform_variable_syntax) means that
doing this the correct way is impossible at the moment without some
really cool self-modifying hackery and `__HALT_COMPILER` nonsense. If
that RFC passes then this solution will work without the trickery.
