### PR TITLE
Since this depends on the call stack, need to look bottom up

### DIFF
--- a/solutions/complete/r/robertzk/goal.R
+++ b/solutions/complete/r/robertzk/goal.R
@@ -4,7 +4,7 @@ g <- function(x) {
   else {
     base <- function(z) if (is.call(z)) Recall(z[[1]]) else deparse(z)
     depth <- function(z) if (is.call(z)) 1 + Recall(z[[1]]) else 0
-    os <- depth(Find(function(y) base(y) == 'g', sys.calls())) - 1
+    os <- depth(Find(function(y) base(y) == 'g', rev(sys.calls()))) - 1
     paste0(c('g', rep('o', os), x), collapse = '')
   }
 }


### PR DESCRIPTION
Or things like `g(g()('al'))` will return `"ggal"` instead of `"ggoal"`
