### PR TITLE
add bel solution

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ already been discovered:
 |:-------------:|:----------------------:|:---------------------:|
 | ActionScript  | [&bull;][as-soln]      |                       |
 | Befunge       | [&bull;][befunge-soln] |                       |
+| Bel           | [&bull;][bel-soln]     |                       |
 | Brainfuck     |                        | [&bull;][bf-soln]     |
 | C             | [&bull;][c-soln]       |                       |
 | C#            | [&bull;][cs-soln]      |                       |
@@ -120,6 +121,7 @@ These are some of the editor's favorite submissions:
 [//]: # (Solution URLs)
 [as-soln]:      https://github.com/eatnumber1/goal/tree/master/solved/actionscript
 [befunge-soln]: https://github.com/eatnumber1/goal/tree/master/solved/befunge-93
+[bel-soln]:     https://github.com/eatnumber1/goal/tree/master/solved/bel
 [bf-soln]:      https://github.com/eatnumber1/goal/tree/master/incomplete/brainfuck
 [c++-soln]:     https://github.com/eatnumber1/goal/tree/master/solved/c++
 [c-soln]:       https://github.com/eatnumber1/goal/tree/master/solved/c

--- a/solved/bel/jeremyschlatter/goal.bel
+++ b/solved/bel/jeremyschlatter/goal.bel
@@ -1,0 +1,9 @@
+(mac g args
+  `(append "g" ,@(map [or (car _) "o"] args)))
+
+(map prn
+  (list
+    (g("al"))
+    (g()("al"))
+    (g()()("al"))
+    (g()()()()("al"))))


### PR DESCRIPTION
You can run it for yourself [here](https://bel-repl.com/?p=qXCez-ZF9Op_0w).

In [Bel](http://paulgraham.com/bel.html) (like other Lisps), `(g()()("al"))` does not denote three function calls, but instead a single call with three arguments: `()`, `()`, and `("al")`.

The `("al")` argument cannot be evaluated, because "al" appears in operator position, and it is undefined what strings do when they appear as operators. So to avoid evaluating it, `g` is defined as a macro rather than a function.

The `g` macro just converts all of its `()` arguments to `"o"`, takes the first element of its non-`()` arguments (like `("al")`, whose first element is `"al"`), and smushes them all together with a `"g"` in front.