### PR TITLE
Add an incomplete solution for Nix.

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ already been discovered:
 | Lua           | [&bull;][lua-soln]     |                       |
 | Mathematica   | [&bull;][math-soln]    |                       |
 | Nimrod        | [&bull;][nim-soln]     |                       |
+| Nix           |                        | [&bull;][nix-soln]    |
 | OCaml         | [&bull;][ocaml-soln]   |                       |
 | Objective-J   | [&bull;][obj-j-soln]   |                       |
 | PHP           |                        | [&bull;][php-soln]    |
@@ -145,6 +146,7 @@ These are some of the editor's favorite submissions:
 [lua-soln]:     https://github.com/eatnumber1/goal/tree/master/solved/lua
 [math-soln]:    https://github.com/eatnumber1/goal/tree/master/solved/mathematica
 [nim-soln]:     https://github.com/eatnumber1/goal/tree/master/solved/nimrod
+[nix-soln]:     https://github.com/eatnumber1/goal/tree/master/incomplete/nix
 [obj-j-soln]:   https://github.com/eatnumber1/goal/tree/master/solved/objective-j
 [ocaml-soln]:   https://github.com/eatnumber1/goal/tree/master/solved/ocaml
 [octave-soln]:  https://github.com/eatnumber1/goal/tree/master/solved/octave

--- a/incomplete/nix/mcsaucy/README.md
+++ b/incomplete/nix/mcsaucy/README.md
@@ -1,0 +1,5 @@
+Run this with `nix repl < ./goal.nix`.
+
+This solution is incomplete. `()` is a syntax error, so that makes `g()("al")`
+a bit of a showstopper. We can use `{}` or `[]` instead and it's visually close
+enough, so `¯\_(ツ)_/¯`.

--- a/incomplete/nix/mcsaucy/goal.nix
+++ b/incomplete/nix/mcsaucy/goal.nix
@@ -1,0 +1,16 @@
+g = let
+  _g = os: x: if x == "al"
+              then "g" + os + "al"
+              else y: _g ("o" + os) y;
+in
+ x: _g "" x
+
+g("al")
+# Unfortunately, () seems to be a syntax error in Nix.
+# {} is visually close, so let's roll with it.
+g{}("al")
+g{}{}("al")
+g{}{}{}("al")
+g{}{}{}{}("al")
+
+g[]("al") # works, too


### PR DESCRIPTION
`()` is a syntax error in Nix, so that makes `g()("al")` a bit tricky.
`g{}{}("al")` works, though.