### PR TITLE
Add a Kotlin solution

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ already been discovered:
 | Java          | [&bull;][java-soln]    |                       |
 | JavaScript    | [&bull;][js-soln]      |                       |
 | Julia         | [&bull;][jl-soln]      |                       |
+| Kotlin        | [&bull;][kt-soln]      |                       |
 | Lua           | [&bull;][lua-soln]     |                       |
 | Mathematica   | [&bull;][math-soln]    |                       |
 | Nimrod        | [&bull;][nim-soln]     |                       |
@@ -145,6 +146,7 @@ These are some of the editor's favorite submissions:
 [java-soln]:    https://github.com/eatnumber1/goal/tree/master/solved/java
 [jl-soln]:      https://github.com/eatnumber1/goal/tree/master/solved/julia
 [js-soln]:      https://github.com/eatnumber1/goal/tree/master/solved/javascript
+[kt-soln]:      https://github.com/eatnumber1/goal/tree/master/solved/kotlin
 [lua-soln]:     https://github.com/eatnumber1/goal/tree/master/solved/lua
 [math-soln]:    https://github.com/eatnumber1/goal/tree/master/solved/mathematica
 [nim-soln]:     https://github.com/eatnumber1/goal/tree/master/solved/nimrod

--- a/solved/kotlin/shawnrc/goal.kt
+++ b/solved/kotlin/shawnrc/goal.kt
@@ -1,0 +1,10 @@
+operator fun String.invoke(a: String = "o") = this + a
+
+val g = "g"
+
+fun main() {
+  println(g()("al"))
+  println(g()()("al"))
+  println(g()()()()("al"))
+  println(g("al"))
+}


### PR DESCRIPTION
Keeps it simple. Technically speaking the invocation could be shortened to `'g'()("al")` but that wouldn't quite match the letter of the rules. 

As an aside, I'm not sure a "purely" functional (i.e. where `g` is actually a function instead of string imbued with a functional extension and there's no other OO shenanigans happening) solution is possible with Kotlin's type system as of 1.4.30 but I'd love to be proven wrong.