### PR TITLE
Add Rust solution

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ already been discovered:
 | R             | [&bull;][r-soln]       |                       |
 | Regexp        |                        | [&bull;][regexp-soln] |
 | Ruby          |                        | [&bull;][rb-soln]     |
+| Rust          | [&bull;][rust-soln]    |                       |
 | Scala         | [&bull;][scala-soln]   |                       |
 | Scheme        | [&bull;][scm-soln]     |                       |
 | Sed           | [&bull;][sed-soln]     |                       |
@@ -160,6 +161,7 @@ These are some of the editor's favorite submissions:
 [py-soln]:      https://github.com/eatnumber1/goal/tree/master/solved/python
 [r-soln]:       https://github.com/eatnumber1/goal/tree/master/solved/r
 [rb-soln]:      https://github.com/eatnumber1/goal/tree/master/incomplete/ruby
+[rust-soln]:    https://github.com/eatnumber1/goal/tree/master/solved/rust
 [regexp-soln]:  https://github.com/eatnumber1/goal/tree/master/incomplete/regexp
 [scala-soln]:   https://github.com/eatnumber1/goal/tree/master/solved/scala
 [scm-soln]:     https://github.com/eatnumber1/goal/tree/master/solved/scheme

--- a/solved/rust/br-lewis/goal.rs
+++ b/solved/rust/br-lewis/goal.rs
@@ -1,0 +1,38 @@
+#![feature(fn_traits)]
+#![feature(unboxed_closures)]
+
+fn main() {
+    // g is moved on each call
+    let g = Goal::new();
+    println!("{}", g("al"));
+    let g = Goal::new();
+    println!("{}", g()("al"));
+    let g = Goal::new();
+    println!("{}", g()()()("al"));
+    let g = Goal::new();
+    println!("{}", g()()()()()()("al"));
+}
+
+struct Goal(String);
+
+impl Goal {
+    fn new() -> Self {
+        Self("g".to_owned())
+    }
+}
+
+impl FnOnce<()> for Goal {
+    type Output = Goal;
+
+    extern "rust-call" fn call_once(self, _args: ()) -> Self::Output {
+        Goal(self.0 + "o")
+    }
+}
+
+impl FnOnce<(&str,)> for Goal {
+    type Output = String;
+
+    extern "rust-call" fn call_once(self, args: (&str,)) -> Self::Output {
+        self.0 + args.0
+    }
+}

--- a/solved/rust/br-lewis/rust-toolchain
+++ b/solved/rust/br-lewis/rust-toolchain
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly-2021-02-16"


### PR DESCRIPTION
This is a pretty straightforward solution that uses [`fn_traits`](https://doc.rust-lang.org/beta/unstable-book/library-features/fn-traits.html) currently only available in nightly. I included [`rust-toolchain`](https://rust-lang.github.io/rustup/overrides.html#the-toolchain-file) with the version of nightly I have at the moment to make this more reproducible.

Closes https://github.com/eatnumber1/goal/issues/14