### PR TITLE
Add bourne shell incomplete solution

### DIFF
--- a/incomplete/bourne-shell/costinteo/goal.sh
+++ b/incomplete/bourne-shell/costinteo/goal.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+CURR="g⟮⟯"
+MAX_ALIAS_NUM=0
+for line in $(cat $0)
+do
+	num=$(( $(echo $line | egrep -o '(⟮⟯)+' | wc -c) / 2 ))
+	[ "$num" -gt "$MAX_ALIAS_NUM" ] && MAX_ALIAS_NUM=$num
+done
+alias g⟮al⟯="echo gal"
+for i in $(seq 0 $MAX_ALIAS_NUM)
+do
+	alias ${CURR}⟮al⟯="echo ${CURR}al | sed 's/⟮⟯/o/g'"
+	CURR="${CURR}⟮⟯"
+done
+g⟮al⟯
+g⟮⟯⟮al⟯
+g⟮⟯⟮⟯⟮al⟯
+g⟮⟯⟮⟯⟮⟯⟮al⟯


### PR DESCRIPTION
Hi! Love the challenge! I've tried making a complete solution for POSIX shell, but I feel like it's bending the rules too much, so I branded it as "incomplete".

Here's the idea: functions in shell aren't called with parantheses. But what if we created aliases that contain parantheses in their names?

Sadly, aliases can't contain the usual parantheses, but they can contain OTHER unicode parantheses characters. So I picked one that looks the most like normal parantheses. (Github's font isn't doing me favours, it looked better locally in my editor :smile:)

Then alias each call iteratively, by determining the maximum amount of aliases needed beforehand.

So:

1. You are encouraged to break the rules, cleverly. :heavy_check_mark: 
2. When executed, the solution must print "goal" with sufficient o's to demonstrate the program's functionality. :heavy_check_mark: 
3. The code g()('al') must appear in the source. :heavy_check_mark: 
-> it does appear, but without the quotes (couldn't get it to work with quotes, so that sucks)
4. g()('al') must not be a string literal. :heavy_check_mark: 
-> it's not a string literal, it's an alias for a real command
5. 'al' must be a string, or your language's equivalent thereof. You may use your language's standard method of creating a string (e.x. C should use ", ruby may use either " or '). :heavy_check_mark: 
-> in POSIX shell, even an unquoted word can be a string
6. g()('al') must be a valid [rvalue](http://en.wikipedia.org/wiki/Value_(computer_science)#lrvalue) if applicable in your language. :heavy_check_mark: 
-> it's technically an rvalue in shell, I can capture the output in a variable
7. g()('al') may not print the string. If returning a string cannot be done in your language, you should submit rationale as to why this is impossible for a solution which prints a string to be accepted. :heavy_check_mark: 
-> shell outputs to stdout to return strings
8. You must be able to insert an arbitrary number of () calls without modification to your solution. :heavy_check_mark:
9. g('al') must return "gal". :heavy_check_mark: